### PR TITLE
fix: add AWS Gateway API Controller IRSA role support

### DIFF
--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -95,6 +95,10 @@ irsa:
     enabled: false                    # (Optional) Create/use the AWS Load Balancer Controller IRSA role. Default: false.
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+  gateway:
+    enabled: false                    # (Optional) Create/use the AWS Gateway API Controller IRSA role. Default: false.
+    namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+    role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
   ebs_csi:
     enabled: false                    # (Optional) Create/use the AWS EBS CSI driver IRSA role. Default: false.
     kms_cmk_ids: []                   # (Optional) Additional KMS CMK ARNs allowed by the EBS CSI policy. Default: [].

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ irsa:
     enabled: false                    # (Optional) Create/use the AWS Load Balancer Controller IRSA role. Default: false.
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+  gateway:
+    enabled: false                    # (Optional) Create/use the AWS Gateway API Controller IRSA role. Default: false.
+    namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+    role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
   ebs_csi:
     enabled: false                    # (Optional) Create/use the AWS EBS CSI driver IRSA role. Default: false.
     kms_cmk_ids: []                   # (Optional) Additional KMS CMK ARNs allowed by the EBS CSI policy. Default: [].
@@ -447,9 +451,9 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.20 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.22.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
 
 ## Modules
 
@@ -462,6 +466,7 @@ Available targets:
 | <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#module\_efs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#module\_ext\_dns\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
+| <a name="module_gateway_irsa_role"></a> [gateway\_irsa\_role](#module\_gateway\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_keda_irsa_role"></a> [keda\_irsa\_role](#module\_keda\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_lb_irsa_role"></a> [lb\_irsa\_role](#module\_lb\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_prometheus_irsa_role"></a> [prometheus\_irsa\_role](#module\_prometheus\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |

--- a/README.md
+++ b/README.md
@@ -451,9 +451,9 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.22.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.20 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -164,6 +164,10 @@ usage: |-
       enabled: false                    # (Optional) Create/use the AWS Load Balancer Controller IRSA role. Default: false.
       namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
       role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+    gateway:
+      enabled: false                    # (Optional) Create/use the AWS Gateway API Controller IRSA role. Default: false.
+      namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+      role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
     ebs_csi:
       enabled: false                    # (Optional) Create/use the AWS EBS CSI driver IRSA role. Default: false.
       kms_cmk_ids: []                   # (Optional) Additional KMS CMK ARNs allowed by the EBS CSI policy. Default: [].

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,9 +14,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.22.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.20 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,9 +14,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.20 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.22.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.1.0 |
 
 ## Modules
 
@@ -29,6 +29,7 @@
 | <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#module\_efs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#module\_ext\_dns\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
+| <a name="module_gateway_irsa_role"></a> [gateway\_irsa\_role](#module\_gateway\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_keda_irsa_role"></a> [keda\_irsa\_role](#module\_keda\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_lb_irsa_role"></a> [lb\_irsa\_role](#module\_lb\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_prometheus_irsa_role"></a> [prometheus\_irsa\_role](#module\_prometheus\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |

--- a/irsa.tf
+++ b/irsa.tf
@@ -62,6 +62,24 @@ module "lb_irsa_role" {
   tags     = local.all_tags
 }
 
+module "gateway_irsa_role" {
+  source                               = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version                              = "~> 6.2"
+  create                               = try(var.irsa.gateway.enabled, false)
+  name                                 = "eks-${local.system_name}-gw-api-role"
+  policy_name                          = "eks-${local.system_name}-gw-api-role-pol"
+  use_name_prefix                      = false
+  attach_aws_gateway_controller_policy = true
+  oidc_providers = {
+    main = {
+      provider_arn               = module.this.oidc_provider_arn
+      namespace_service_accounts = try(var.irsa.gateway.namespace_service_accounts, [])
+    }
+  }
+  policies = try(var.irsa.gateway.role_policy_arns, {})
+  tags     = local.all_tags
+}
+
 module "ebs_csi_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version               = "~> 6.2"

--- a/variables-eks.tf
+++ b/variables-eks.tf
@@ -133,6 +133,10 @@ variable "access_cidrs" {
 #     enabled: false                    # (Optional) Create/use the load balancer controller IRSA role. Default: false.
 #     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
 #     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+#   gateway:                            # (Optional) AWS Gateway API Controller IRSA role configuration. Default: disabled.
+#     enabled: false                    # (Optional) Create/use the AWS Gateway API controller IRSA role. Default: false.
+#     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+#     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
 #   ebs_csi:                            # (Optional) AWS EBS CSI driver IRSA role configuration. Default: disabled.
 #     enabled: false                    # (Optional) Create/use the EBS CSI IRSA role. Default: false.
 #     kms_cmk_ids: []                   # (Optional) Additional KMS CMK ARNs allowed by the EBS CSI policy. Default: [].


### PR DESCRIPTION
## Summary

- Add `gateway_irsa_role` module in `irsa.tf` using `attach_aws_gateway_controller_policy = true`
- Document `gateway` block in `variables-eks.tf` inline comments for the `irsa` variable
- Add `gateway` entry to `.boilerplate/inputs.yaml` for operator scaffolding
- Update `README.yaml` usage example to include the `gateway` IRSA block
- Regenerate `README.md` and `docs/terraform.md`

+semver: fix