### PR TITLE
fix: add missing gateway IRSA role output

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ Available targets:
 | <a name="output_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#output\_efs\_csi\_irsa\_role) | n/a |
 | <a name="output_eks_worker_key"></a> [eks\_worker\_key](#output\_eks\_worker\_key) | n/a |
 | <a name="output_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#output\_ext\_dns\_irsa\_role) | n/a |
+| <a name="output_gateway_irsa_role"></a> [gateway\_irsa\_role](#output\_gateway\_irsa\_role) | AWS Gateway API Controller IRSA role ARN and name |
 | <a name="output_keda_irsa_role"></a> [keda\_irsa\_role](#output\_keda\_irsa\_role) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | n/a |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -141,6 +141,7 @@
 | <a name="output_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#output\_efs\_csi\_irsa\_role) | n/a |
 | <a name="output_eks_worker_key"></a> [eks\_worker\_key](#output\_eks\_worker\_key) | n/a |
 | <a name="output_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#output\_ext\_dns\_irsa\_role) | n/a |
+| <a name="output_gateway_irsa_role"></a> [gateway\_irsa\_role](#output\_gateway\_irsa\_role) | AWS Gateway API Controller IRSA role ARN and name |
 | <a name="output_keda_irsa_role"></a> [keda\_irsa\_role](#output\_keda\_irsa\_role) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | n/a |

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -62,6 +62,14 @@ output "cluster_sg_worker" {
   value = {
     name = aws_security_group.worker.name
     id   = aws_security_group.worker.id
+  }
+}
+
+output "gateway_irsa_role" {
+  description = "AWS Gateway API Controller IRSA role ARN and name"
+  value = {
+    arn  = module.gateway_irsa_role.arn
+    name = module.gateway_irsa_role.name
   }
 }
 


### PR DESCRIPTION
## Summary

- Add missing \`gateway_irsa_role\` output block in \`output.tf\`
- The \`module.gateway_irsa_role\` was defined in \`irsa.tf\` (line 65) but had no corresponding output, unlike every other IRSA role module
- Output exposes \`arn\` and \`name\` attributes, consistent with all other IRSA role outputs
- Update copyright year to 2026 in \`output.tf\` header

+semver: fix