### PR TITLE
feat: wire optional S3 CSI, external-dns and cert-manager addons with IRSA, add External Secrets IRSA role

### DIFF
--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -91,6 +91,12 @@ addons:
     enabled: false                    # (Optional) Enable eks-pod-identity-agent addon. Default: false.
   adot:
     enabled: false                    # (Optional) Enable AWS Distro for OpenTelemetry addon. Default: false.
+  s3:
+    enabled: false                    # (Optional) Enable aws-mountpoint-s3-csi-driver addon. Default: false.
+  external_dns:
+    enabled: false                    # (Optional) Enable external-dns community addon. Default: false.
+  cert_manager:
+    enabled: false                    # (Optional) Enable cert-manager community addon. Default: false.
 
 irsa:
   vpc_cni:
@@ -117,6 +123,12 @@ irsa:
   external_dns:
     enabled: false                    # (Optional) Create/use the ExternalDNS IRSA role. Default: false.
     hosted_zone_arns: []              # (Optional) Route53 hosted zone ARNs managed by ExternalDNS. Default: [].
+    namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+    role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+  external_secrets:
+    enabled: false                    # (Optional) Create/use the External Secrets Operator IRSA role. Default: false.
+    ssm_parameter_arns: []            # (Optional) SSM parameter ARNs readable by the operator. Default: [].
+    secrets_manager_arns: []          # (Optional) AWS Secrets Manager secret ARNs readable by the operator. Default: [].
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
   cluster_autoscaler:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ addons:
     enabled: false                    # (Optional) Enable eks-pod-identity-agent addon. Default: false.
   adot:
     enabled: false                    # (Optional) Enable AWS Distro for OpenTelemetry addon. Default: false.
+  s3:
+    enabled: false                    # (Optional) Enable aws-mountpoint-s3-csi-driver addon. Default: false.
+  external_dns:
+    enabled: false                    # (Optional) Enable external-dns community addon. Default: false.
+  cert_manager:
+    enabled: false                    # (Optional) Enable cert-manager community addon. Default: false.
 
 irsa:
   vpc_cni:
@@ -212,6 +218,12 @@ irsa:
   external_dns:
     enabled: false                    # (Optional) Create/use the ExternalDNS IRSA role. Default: false.
     hosted_zone_arns: []              # (Optional) Route53 hosted zone ARNs managed by ExternalDNS. Default: [].
+    namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+    role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+  external_secrets:
+    enabled: false                    # (Optional) Create/use the External Secrets Operator IRSA role. Default: false.
+    ssm_parameter_arns: []            # (Optional) SSM parameter ARNs readable by the operator. Default: [].
+    secrets_manager_arns: []          # (Optional) AWS Secrets Manager secret ARNs readable by the operator. Default: [].
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
   cluster_autoscaler:
@@ -458,9 +470,9 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
 
 ## Modules
 
@@ -473,6 +485,7 @@ Available targets:
 | <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#module\_efs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#module\_ext\_dns\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
+| <a name="module_external_secrets_irsa_role"></a> [external\_secrets\_irsa\_role](#module\_external\_secrets\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_gateway_irsa_role"></a> [gateway\_irsa\_role](#module\_gateway\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_keda_irsa_role"></a> [keda\_irsa\_role](#module\_keda\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_lb_irsa_role"></a> [lb\_irsa\_role](#module\_lb\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
@@ -586,6 +599,7 @@ Available targets:
 | <a name="output_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#output\_efs\_csi\_irsa\_role) | n/a |
 | <a name="output_eks_worker_key"></a> [eks\_worker\_key](#output\_eks\_worker\_key) | n/a |
 | <a name="output_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#output\_ext\_dns\_irsa\_role) | n/a |
+| <a name="output_external_secrets_irsa_role"></a> [external\_secrets\_irsa\_role](#output\_external\_secrets\_irsa\_role) | External Secrets Operator IRSA role ARN and name |
 | <a name="output_gateway_irsa_role"></a> [gateway\_irsa\_role](#output\_gateway\_irsa\_role) | AWS Gateway API Controller IRSA role ARN and name |
 | <a name="output_keda_irsa_role"></a> [keda\_irsa\_role](#output\_keda\_irsa\_role) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |

--- a/README.md
+++ b/README.md
@@ -470,9 +470,9 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -160,6 +160,12 @@ usage: |-
       enabled: false                    # (Optional) Enable eks-pod-identity-agent addon. Default: false.
     adot:
       enabled: false                    # (Optional) Enable AWS Distro for OpenTelemetry addon. Default: false.
+    s3:
+      enabled: false                    # (Optional) Enable aws-mountpoint-s3-csi-driver addon. Default: false.
+    external_dns:
+      enabled: false                    # (Optional) Enable external-dns community addon. Default: false.
+    cert_manager:
+      enabled: false                    # (Optional) Enable cert-manager community addon. Default: false.
 
   irsa:
     vpc_cni:
@@ -186,6 +192,12 @@ usage: |-
     external_dns:
       enabled: false                    # (Optional) Create/use the ExternalDNS IRSA role. Default: false.
       hosted_zone_arns: []              # (Optional) Route53 hosted zone ARNs managed by ExternalDNS. Default: [].
+      namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+      role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+    external_secrets:
+      enabled: false                    # (Optional) Create/use the External Secrets Operator IRSA role. Default: false.
+      ssm_parameter_arns: []            # (Optional) SSM parameter ARNs readable by the operator. Default: [].
+      secrets_manager_arns: []          # (Optional) AWS Secrets Manager secret ARNs readable by the operator. Default: [].
       namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
       role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
     cluster_autoscaler:

--- a/addons.tf
+++ b/addons.tf
@@ -58,6 +58,32 @@ locals {
       service_account_role_arn = try(var.irsa.adot.enabled, false) ? local.adot_irsa_role_arn : null
     }
   } : {}
-  cluster_addons = merge(local.basic_addons, local.efs_addon, local.snapshot_addon, local.cloudwatch_addon,
-  local.pod_identity_addon, local.adot_addon)
+  s3_addon = try(var.addons.s3.enabled, false) ? {
+    aws-mountpoint-s3-csi-driver = {
+      most_recent              = true
+      service_account_role_arn = try(var.irsa.s3_csi.enabled, false) ? local.s3_csi_irsa_role_arn : null
+    }
+  } : {}
+  external_dns_addon = try(var.addons.external_dns.enabled, false) ? {
+    external-dns = {
+      most_recent              = true
+      service_account_role_arn = try(var.irsa.external_dns.enabled, false) ? local.external_dns_irsa_role_arn : null
+    }
+  } : {}
+  cert_manager_addon = try(var.addons.cert_manager.enabled, false) ? {
+    cert-manager = {
+      most_recent              = true
+      service_account_role_arn = try(var.irsa.cert_manager.enabled, false) ? local.cert_manager_irsa_role_arn : null
+    }
+  } : {}
+  cluster_addons = merge(local.basic_addons,
+    local.efs_addon,
+    local.snapshot_addon,
+    local.cloudwatch_addon,
+    local.pod_identity_addon,
+    local.adot_addon,
+    local.s3_addon,
+    local.external_dns_addon,
+    local.cert_manager_addon
+  )
 }

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,9 +14,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
 
 ## Modules
 
@@ -29,6 +29,7 @@
 | <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#module\_efs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#module\_ext\_dns\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
+| <a name="module_external_secrets_irsa_role"></a> [external\_secrets\_irsa\_role](#module\_external\_secrets\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_gateway_irsa_role"></a> [gateway\_irsa\_role](#module\_gateway\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_keda_irsa_role"></a> [keda\_irsa\_role](#module\_keda\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
 | <a name="module_lb_irsa_role"></a> [lb\_irsa\_role](#module\_lb\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | ~> 6.2 |
@@ -142,6 +143,7 @@
 | <a name="output_efs_csi_irsa_role"></a> [efs\_csi\_irsa\_role](#output\_efs\_csi\_irsa\_role) | n/a |
 | <a name="output_eks_worker_key"></a> [eks\_worker\_key](#output\_eks\_worker\_key) | n/a |
 | <a name="output_ext_dns_irsa_role"></a> [ext\_dns\_irsa\_role](#output\_ext\_dns\_irsa\_role) | n/a |
+| <a name="output_external_secrets_irsa_role"></a> [external\_secrets\_irsa\_role](#output\_external\_secrets\_irsa\_role) | External Secrets Operator IRSA role ARN and name |
 | <a name="output_gateway_irsa_role"></a> [gateway\_irsa\_role](#output\_gateway\_irsa\_role) | AWS Gateway API Controller IRSA role ARN and name |
 | <a name="output_keda_irsa_role"></a> [keda\_irsa\_role](#output\_keda\_irsa\_role) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,9 +14,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/irsa.tf
+++ b/irsa.tf
@@ -8,21 +8,31 @@
 #
 
 locals {
-  policy_prefix                = "eks-${local.system_name_short}-"
-  vpc_cni_irsa_role_name       = "eks-${local.system_name}-vpc-cni-role"
-  vpc_cni_irsa_role_arn        = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.vpc_cni_irsa_role_name}"
-  ebs_cni_irsa_role_name       = "eks-${local.system_name}-ebs-csi-role"
-  ebs_cni_irsa_role_arn        = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.ebs_cni_irsa_role_name}"
-  efs_cni_irsa_role_name       = "eks-${local.system_name}-efs-csi-role"
-  efs_cni_irsa_role_arn        = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.efs_cni_irsa_role_name}"
-  cloudwatch_irsa_role_name    = "eks-${local.system_name}-cw-observability-role"
-  cloudwatch_irsa_role_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.cloudwatch_irsa_role_name}"
-  secrets_store_irsa_role_name = "eks-${local.system_name}-secrets-store-role"
-  secrets_store_irsa_role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.secrets_store_irsa_role_name}"
-  adot_irsa_role_name          = "eks-${local.system_name}-adot-role"
-  adot_irsa_role_arn           = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.adot_irsa_role_name}"
-  keda_irsa_role_name          = "eks-${local.system_name}-keda-role"
-  keda_irsa_role_arn           = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.keda_irsa_role_name}"
+  policy_prefix                   = "eks-${local.system_name_short}-"
+  vpc_cni_irsa_role_name          = "eks-${local.system_name}-vpc-cni-role"
+  vpc_cni_irsa_role_arn           = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.vpc_cni_irsa_role_name}"
+  ebs_cni_irsa_role_name          = "eks-${local.system_name}-ebs-csi-role"
+  ebs_cni_irsa_role_arn           = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.ebs_cni_irsa_role_name}"
+  efs_cni_irsa_role_name          = "eks-${local.system_name}-efs-csi-role"
+  efs_cni_irsa_role_arn           = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.efs_cni_irsa_role_name}"
+  cloudwatch_irsa_role_name       = "eks-${local.system_name}-cw-observability-role"
+  cloudwatch_irsa_role_arn        = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.cloudwatch_irsa_role_name}"
+  secrets_store_irsa_role_name    = "eks-${local.system_name}-secrets-store-role"
+  secrets_store_irsa_role_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.secrets_store_irsa_role_name}"
+  adot_irsa_role_name             = "eks-${local.system_name}-adot-role"
+  adot_irsa_role_arn              = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.adot_irsa_role_name}"
+  keda_irsa_role_name             = "eks-${local.system_name}-keda-role"
+  keda_irsa_role_arn              = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.keda_irsa_role_name}"
+  s3_csi_irsa_role_name           = "eks-${local.system_name}-s3-csi-role"
+  s3_csi_irsa_role_arn            = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.s3_csi_irsa_role_name}"
+  external_secrets_irsa_role_name = "eks-${local.system_name}-external-secrets-role"
+  external_secrets_irsa_role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.external_secrets_irsa_role_name}"
+  external_dns_irsa_role_name     = "eks-${local.system_name}-ext-dns-role"
+  external_dns_irsa_role_arn      = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.external_dns_irsa_role_name}"
+  cert_manager_irsa_role_name     = "eks-${local.system_name}-cert-mgr-role"
+  cert_manager_irsa_role_arn      = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.cert_manager_irsa_role_name}"
+  prometheus_irsa_role_name       = "eks-${local.system_name}-prometheus-role"
+  prometheus_irsa_role_arn        = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.prometheus_irsa_role_name}"
 }
 
 module "vpc_cni_irsa_role" {
@@ -121,8 +131,8 @@ module "ext_dns_irsa_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                       = "~> 6.2"
   create                        = try(var.irsa.external_dns.enabled, false)
-  name                          = "eks-${local.system_name}-ext-dns-role"
-  policy_name                   = "eks-${local.system_name}-ext-dns-role-pol"
+  name                          = local.external_dns_irsa_role_name
+  policy_name                   = "${local.external_dns_irsa_role_name}-pol"
   use_name_prefix               = false
   attach_external_dns_policy    = true
   external_dns_hosted_zone_arns = try(var.irsa.external_dns.hosted_zone_arns, [])
@@ -159,8 +169,8 @@ module "cert_mgr_irsa_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                       = "~> 6.2"
   create                        = try(var.irsa.cert_manager.enabled, false)
-  name                          = "eks-${local.system_name}-cert-mgr-role"
-  policy_name                   = "eks-${local.system_name}-cert-mgr-role-pol"
+  name                          = local.cert_manager_irsa_role_name
+  policy_name                   = "${local.cert_manager_irsa_role_name}-pol"
   use_name_prefix               = false
   attach_cert_manager_policy    = true
   cert_manager_hosted_zone_arns = try(var.irsa.cert_manager.hosted_zone_arns, [])
@@ -178,8 +188,8 @@ module "s3_csi_irsa_role" {
   source                          = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                         = "~> 6.2"
   create                          = try(var.irsa.s3_csi.enabled, false)
-  name                            = "eks-${local.system_name}-s3-csi-role"
-  policy_name                     = "eks-${local.system_name}-s3-csi-role-pol"
+  name                            = local.s3_csi_irsa_role_name
+  policy_name                     = "${local.s3_csi_irsa_role_name}-pol"
   use_name_prefix                 = false
   attach_mountpoint_s3_csi_policy = true
   mountpoint_s3_csi_bucket_arns   = try(var.irsa.s3_csi.bucket_arns, [])
@@ -218,8 +228,8 @@ module "prometheus_irsa_role" {
   source                                           = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version                                          = "~> 6.2"
   create                                           = try(var.irsa.prometheus.enabled, false)
-  name                                             = "eks-${local.system_name}-prometheus-role"
-  policy_name                                      = "eks-${local.system_name}-prometheus-role-pol"
+  name                                             = local.prometheus_irsa_role_name
+  policy_name                                      = "${local.prometheus_irsa_role_name}-pol"
   use_name_prefix                                  = false
   attach_amazon_managed_service_prometheus_policy  = true
   amazon_managed_service_prometheus_workspace_arns = try(var.irsa.prometheus.workspace_arns, [])
@@ -310,3 +320,24 @@ module "keda_irsa_role" {
   policies = try(var.irsa.keda.role_policy_arns, {})
   tags     = local.all_tags
 }
+
+module "external_secrets_irsa_role" {
+  source                                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version                               = "~> 6.2"
+  create                                = try(var.irsa.external_secrets.enabled, false)
+  name                                  = local.external_secrets_irsa_role_name
+  policy_name                           = "${local.external_secrets_irsa_role_name}-pol"
+  use_name_prefix                       = false
+  attach_external_secrets_policy        = true
+  external_secrets_ssm_parameter_arns   = try(var.irsa.external_secrets.ssm_parameter_arns, [])
+  external_secrets_secrets_manager_arns = try(var.irsa.external_secrets.secrets_manager_arns, [])
+  oidc_providers = {
+    main = {
+      provider_arn               = module.this.oidc_provider_arn
+      namespace_service_accounts = try(var.irsa.external_secrets.namespace_service_accounts, [])
+    }
+  }
+  policies = try(var.irsa.external_secrets.role_policy_arns, {})
+  tags     = local.all_tags
+}
+

--- a/output.tf
+++ b/output.tf
@@ -157,6 +157,14 @@ output "secrets_store_irsa_role" {
   }
 }
 
+output "external_secrets_irsa_role" {
+  description = "External Secrets Operator IRSA role ARN and name"
+  value = {
+    arn  = module.external_secrets_irsa_role.arn
+    name = module.external_secrets_irsa_role.name
+  }
+}
+
 output "cloudwatch_irsa_role" {
   value = {
     arn  = module.cloudwatch_irsa_role.arn

--- a/variables-eks.tf
+++ b/variables-eks.tf
@@ -151,6 +151,12 @@ variable "access_cidrs" {
 #     hosted_zone_arns: []              # (Optional) Route53 hosted zone ARNs managed by ExternalDNS. Default: [].
 #     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
 #     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
+#   external_secrets:                   # (Optional) External Secrets Operator IRSA role configuration. Default: disabled.
+#     enabled: false                    # (Optional) Create/use the External Secrets Operator IRSA role. Default: false.
+#     ssm_parameter_arns: []            # (Optional) SSM parameter ARNs readable by the operator. Default: [].
+#     secrets_manager_arns: []          # (Optional) AWS Secrets Manager secret ARNs readable by the operator. Default: [].
+#     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
+#     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
 #   cluster_autoscaler:                 # (Optional) Cluster Autoscaler IRSA role configuration. Default: disabled.
 #     enabled: false                    # (Optional) Create/use the Cluster Autoscaler IRSA role. Default: false.
 #     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
@@ -249,6 +255,12 @@ variable "role_name_compat" {
 #     enabled: false                  # (Optional) Enable eks-pod-identity-agent addon. Default: false.
 #   adot:
 #     enabled: false                  # (Optional) Enable AWS Distro for OpenTelemetry addon. Default: false.
+#   s3:
+#     enabled: false                  # (Optional) Enable aws-mountpoint-s3-csi-driver addon. Default: false.
+#   external_dns:
+#     enabled: false                  # (Optional) Enable external-dns community addon. Default: false.
+#   cert_manager:
+#     enabled: false                  # (Optional) Enable cert-manager community addon. Default: false.
 variable "addons" {
   description = "Optional EKS addon toggles layered on top of the base coredns, kube-proxy, vpc-cni, and ebs-csi addons."
   type        = any


### PR DESCRIPTION
## Summary

- Add optional EKS addons gated by `var.addons`: `aws-mountpoint-s3-csi-driver` (`addons.s3`), `external-dns` and `cert-manager` community addons, each wired to its existing IRSA role ARN when the matching `irsa.*` entry is enabled
- Add External Secrets Operator IRSA role (`irsa.external_secrets`) with SSM parameter and Secrets Manager ARN scoping, plus `external_secrets_irsa_role` output
- Introduce role name/ARN locals for s3_csi, external_dns, cert_manager, external_secrets and prometheus roles; refactor existing modules to consume them (role names unchanged)
- Document new `addons.*` and `irsa.external_secrets` keys in `variables-eks.tf`, `.boilerplate/inputs.yaml` and `README.yaml`; regenerate `README.md` and `docs/terraform.md`

+semver: minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)