### PR TITLE
fix: KEDA scaler policy try() fallbacks, CloudWatch scaler resource default and docs sync

### DIFF
--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -169,6 +169,15 @@ irsa:
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
   keda:
-    enabled: false                    # (Optional) Create/use the KEDA IRSA role. No policies attached by default. Default: false.
+    enabled: false                    # (Optional) Create/use the KEDA IRSA role. Scaler policies are attached only for the scaler blocks enabled below. Default: false.
+    sqs:
+      enabled: false                  # (Optional) Attach the SQS scaler read policy. Default: false.
+      queue_arns: []                  # (Required when enabled) SQS queue ARNs readable by KEDA. Default: [].
+    dynamodb:
+      enabled: false                  # (Optional) Attach the DynamoDB scaler read policy. Default: false.
+      table_arns: []                  # (Required when enabled) DynamoDB table/stream ARNs readable by KEDA. Default: [].
+    cloudwatch:
+      enabled: false                  # (Optional) Attach the CloudWatch scaler read policy. Default: false.
+      arns: ["*"]                     # (Optional) Resource ARNs; metric read APIs only support "*", DescribeAlarms honors alarm ARNs. Default: ["*"].
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
-    role_policy_arns: {}              # (Optional) IAM policy ARNs granting scaler permissions (e.g. CloudWatch/SQS read). Default: {}.
+    role_policy_arns: {}              # (Optional) Extra IAM policy ARNs for additional scalers. Default: {}.

--- a/README.md
+++ b/README.md
@@ -474,9 +474,9 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -264,9 +264,18 @@ irsa:
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
   keda:
-    enabled: false                    # (Optional) Create/use the KEDA IRSA role. No policies attached by default. Default: false.
+    enabled: false                    # (Optional) Create/use the KEDA IRSA role. Scaler policies are attached only for the scaler blocks enabled below. Default: false.
+    sqs:
+      enabled: false                  # (Optional) Attach the SQS scaler read policy. Default: false.
+      queue_arns: []                  # (Required when enabled) SQS queue ARNs readable by KEDA. Default: [].
+    dynamodb:
+      enabled: false                  # (Optional) Attach the DynamoDB scaler read policy. Default: false.
+      table_arns: []                  # (Required when enabled) DynamoDB table/stream ARNs readable by KEDA. Default: [].
+    cloudwatch:
+      enabled: false                  # (Optional) Attach the CloudWatch scaler read policy. Default: false.
+      arns: ["*"]                     # (Optional) Resource ARNs; metric read APIs only support "*", DescribeAlarms honors alarm ARNs. Default: ["*"].
     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
-    role_policy_arns: {}              # (Optional) IAM policy ARNs granting scaler permissions (e.g. CloudWatch/SQS read). Default: {}.
+    role_policy_arns: {}              # (Optional) Extra IAM policy ARNs for additional scalers. Default: {}.
 ```
 
 ## Generated `terragrunt.hcl`
@@ -465,9 +474,9 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -238,9 +238,18 @@ usage: |-
       namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
       role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
     keda:
-      enabled: false                    # (Optional) Create/use the KEDA IRSA role. No policies attached by default. Default: false.
+      enabled: false                    # (Optional) Create/use the KEDA IRSA role. Scaler policies are attached only for the scaler blocks enabled below. Default: false.
+      sqs:
+        enabled: false                  # (Optional) Attach the SQS scaler read policy. Default: false.
+        queue_arns: []                  # (Required when enabled) SQS queue ARNs readable by KEDA. Default: [].
+      dynamodb:
+        enabled: false                  # (Optional) Attach the DynamoDB scaler read policy. Default: false.
+        table_arns: []                  # (Required when enabled) DynamoDB table/stream ARNs readable by KEDA. Default: [].
+      cloudwatch:
+        enabled: false                  # (Optional) Attach the CloudWatch scaler read policy. Default: false.
+        arns: ["*"]                     # (Optional) Resource ARNs; metric read APIs only support "*", DescribeAlarms honors alarm ARNs. Default: ["*"].
       namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
-      role_policy_arns: {}              # (Optional) IAM policy ARNs granting scaler permissions (e.g. CloudWatch/SQS read). Default: {}.
+      role_policy_arns: {}              # (Optional) Extra IAM policy ARNs for additional scalers. Default: {}.
   ```
 
   ## Generated `terragrunt.hcl`

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,9 +14,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,9 +14,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.53.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.42, < 7.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/irsa.tf
+++ b/irsa.tf
@@ -307,8 +307,8 @@ module "adot_irsa_role" {
 }
 
 data "aws_iam_policy_document" "keda_policy_document_sqs" {
-  count = try(var.irsa.keda.enabled, false) && try(var.irsa.keda.sqs.enabled) ? 1 : 0
-  # KEDA SQS SCALER POlICY DOCUMENT
+  count = try(var.irsa.keda.enabled, false) && try(var.irsa.keda.sqs.enabled, false) ? 1 : 0
+  # KEDA SQS SCALER POLICY DOCUMENT
   statement {
     sid    = "KedaSQSPolicy"
     effect = "Allow"
@@ -323,8 +323,8 @@ data "aws_iam_policy_document" "keda_policy_document_sqs" {
 }
 
 data "aws_iam_policy_document" "keda_policy_document_dynamodb" {
-  count = try(var.irsa.keda.enabled, false) && try(var.irsa.keda.dynamodb.enabled) ? 1 : 0
-  # KEDA DYNAMODB SCALER POLICY DOCUMENT}
+  count = try(var.irsa.keda.enabled, false) && try(var.irsa.keda.dynamodb.enabled, false) ? 1 : 0
+  # KEDA DYNAMODB SCALER POLICY DOCUMENT
   statement {
     sid    = "KedaDynamoDBPolicy"
     effect = "Allow"
@@ -338,7 +338,7 @@ data "aws_iam_policy_document" "keda_policy_document_dynamodb" {
 }
 
 data "aws_iam_policy_document" "keda_policy_document_cw" {
-  count = try(var.irsa.keda.enabled, false) && try(var.irsa.keda.cloudwatch.enabled) ? 1 : 0
+  count = try(var.irsa.keda.enabled, false) && try(var.irsa.keda.cloudwatch.enabled, false) ? 1 : 0
   # KEDA CLOUDWATCH SCALER POLICY DOCUMENT
   statement {
     sid    = "KedaCloudWatchPolicy"
@@ -349,7 +349,9 @@ data "aws_iam_policy_document" "keda_policy_document_cw" {
       "cloudwatch:GetMetricStatistics",
       "cloudwatch:ListMetrics"
     ]
-    resources = try(var.irsa.keda.cloudwatch.arns, [])
+    # CloudWatch metric read APIs (GetMetricData/GetMetricStatistics/ListMetrics)
+    # do not support resource-level scoping; only DescribeAlarms honors ARNs.
+    resources = try(var.irsa.keda.cloudwatch.arns, ["*"])
   }
 }
 

--- a/variables-eks.tf
+++ b/variables-eks.tf
@@ -194,10 +194,19 @@ variable "access_cidrs" {
 #     workspace_arns: []                # (Optional) AMP workspace ARNs for remote write; attaches the AMP remote-write policy when non-empty. Default: [].
 #     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
 #     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs. Default: {}.
-#   keda:                               # (Optional) KEDA IRSA role configuration. No policies attached by default. Default: disabled.
+#   keda:                               # (Optional) KEDA IRSA role configuration. Scaler policies are attached only for the scaler blocks enabled below. Default: disabled.
 #     enabled: false                    # (Optional) Create/use the KEDA IRSA role. Default: false.
+#     sqs:                              # (Optional) SQS scaler read permissions. Default: disabled.
+#       enabled: false                  # (Optional) Attach the SQS scaler policy. Default: false.
+#       queue_arns: []                  # (Required when enabled) SQS queue ARNs readable by KEDA. Default: [].
+#     dynamodb:                         # (Optional) DynamoDB scaler read permissions. Default: disabled.
+#       enabled: false                  # (Optional) Attach the DynamoDB scaler policy. Default: false.
+#       table_arns: []                  # (Required when enabled) DynamoDB table/stream ARNs readable by KEDA. Default: [].
+#     cloudwatch:                       # (Optional) CloudWatch scaler read permissions. Default: disabled.
+#       enabled: false                  # (Optional) Attach the CloudWatch scaler policy. Default: false.
+#       arns: ["*"]                     # (Optional) Resource ARNs; metric read APIs only support "*", DescribeAlarms honors alarm ARNs. Default: ["*"].
 #     namespace_service_accounts: []    # (Optional) namespace:service_account bindings. Default: [].
-#     role_policy_arns: {}              # (Optional) IAM policy ARNs granting scaler permissions (e.g. CloudWatch/SQS read). Default: {}.
+#     role_policy_arns: {}              # (Optional) Extra IAM policy ARNs for additional scalers. Default: {}.
 variable "irsa" {
   description = "IRSA configuration settings for supported EKS controllers and CSI drivers."
   type        = any


### PR DESCRIPTION
## Summary

- Add missing `false` fallback to the sqs/dynamodb/cloudwatch scaler enable checks so plans no longer fail when a scaler block is not defined
- Default the CloudWatch scaler policy resources to `["*"]`; metric read APIs (GetMetricData/GetMetricStatistics/ListMetrics) do not support resource-level scoping and an empty resource list rendered an invalid IAM policy
- Fix scaler policy comment typos
- Document the new `irsa.keda.sqs`, `irsa.keda.dynamodb` and `irsa.keda.cloudwatch` keys in `variables-eks.tf`, `.boilerplate/inputs.yaml` and `README.yaml`; regenerate `README.md` and `docs/terraform.md`

+semver: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)